### PR TITLE
feat(cache): switch to per-root bulk cache and fs watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ See the example below for how to configure **tool-resolver.nvim**.
  cmd = {
   "ToolResolverGetTool",
   "ToolResolverGetTools",
-  "ToolResolverClearCache",
-  "ToolResolverGetCache",
  },
  ---@type ToolResolver.Config
  opts = {

--- a/doc/tool-resolver.nvim.txt
+++ b/doc/tool-resolver.nvim.txt
@@ -108,8 +108,6 @@ See the example below for how to configure **tool-resolver.nvim**.
      cmd = {
       "ToolResolverGetTool",
       "ToolResolverGetTools",
-      "ToolResolverClearCache",
-      "ToolResolverGetCache",
      },
      ---@type ToolResolver.Config
      opts = {

--- a/lua/tool-resolver/cache.lua
+++ b/lua/tool-resolver/cache.lua
@@ -1,43 +1,69 @@
 local M = {}
 
--- Internal binary cache table, do not modify directly
-local _cache = {}
+local uv = vim.uv or vim.loop
 
----Generate a normalized cache key for a tool with optional root
----@param root? string # Optional project root (or nil for global)
----@param tool string # Tool name (e.g., "eslint", "prettier")
----@return string # Normalized cache key
-function M.get_key(root, tool)
-	return (root or "__NO_ROOT__") .. ":" .. tool
+---@type table<string, table<string, string|false>>
+local root_cache = {}
+
+---@type table<string, uv.uv_fs_poll_t>
+local watchers = {}
+
+local global_cache_key = "__GLOBAL__"
+
+---Return the entire tool→binary map for a given project root.
+---@param root? string Absolute project root; `nil` means global scope
+---@return table<string, string|false> root_table Map of tool names → absolute executable paths (empty table if never cached)
+function M.get_root_table(root)
+	return root_cache[root or global_cache_key] or {}
 end
 
----Get a shallow copy of the entire cache (read-only)
----@return table<string, string> # Copy of internal cache table
-function M.get()
-	local copy = {}
-	for k, v in pairs(_cache) do
-		copy[k] = v
+---Retrieve the cached absolute path of a tool inside a given project root.
+---@param root? string Absolute project root (or nil for global scope)
+---@param tool string Tool name (e.g. `"biome"`)
+---@return string|nil bin Absolute path if found, `false` if explicitly not found, `nil` if never cached
+function M.get_bin(root, tool)
+	local t = root_cache[root or global_cache_key]
+	return t and t[tool] or nil
+end
+
+---Store an entire tool→binary map for a project root.
+---@param root? string Absolute project root (or nil for global scope)
+---@param tool_map table<string, string|false> Map of tool names → absolute binary paths
+function M.set_root(root, tool_map)
+	root_cache[root or global_cache_key] = tool_map
+end
+
+---Drop the cache for one project root (and stop its watcher).
+---@param root? string Absolute project root (or nil for global scope)
+function M.clear_root(root)
+	root = root or "__GLOBAL__"
+	root_cache[root] = nil
+	if watchers[root] then
+		watchers[root]:stop()
+		watchers[root]:close()
+		watchers[root] = nil
 	end
-	return copy
 end
 
----Get a cached binary path by key
----@param key string # Cache key
----@return string|nil # Cached binary path, or nil if not found
-function M.get_by_key(key)
-	return _cache[key]
-end
+---Start a file-system watcher on `<root>/<subpath…>` so that any
+---create/delete inside that directory triggers `clear_root(root)`.
+---@param root string Absolute project root
+---@param subpath string[] Path segments *relative* to `root` (e.g. `{ "node_modules", ".bin" }`)
+function M.watch_root(root, subpath)
+	if watchers[root] then
+		return
+	end
+	local bin_dir = root .. "/" .. table.concat(subpath, "/")
 
----Set a binary path for the given key
----@param key string # Cache key
----@param bin string # Resolved binary path
-function M.set(key, bin)
-	_cache[key] = bin
-end
+	local h = uv.new_fs_poll()
+	if not h then
+		return
+	end
 
----Clear the entire binary cache
-function M.clear()
-	_cache = {}
+	h:start(bin_dir, 2000, function()
+		M.clear_root(root)
+	end)
+	watchers[root] = h
 end
 
 return M

--- a/lua/tool-resolver/types.lua
+++ b/lua/tool-resolver/types.lua
@@ -9,3 +9,7 @@
 ---@field path? string start search path (default: current buffer)
 
 ---@alias ToolResolver.ResolverType "node" -- add more in future
+
+---@class ToolResolver.ResolverMeta
+---@field root_markers string[] root_markers
+---@field bin_subpath string[] bin_subpath


### PR DESCRIPTION
- replace single-key cache with O(1) per-root tool map
- scan node_modules/.bin once per project root, then reuse
- add uv_fs_poll watcher to auto-invalidate on changes
- add resolver meta
- remove _cache layer
- make resolution async via vim.defer_fn pre-warm
