### PR TITLE
fix(docs): switch from `pandocvim` to `vimcats` for docs generation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,17 @@ jobs:
             - name: Create /doc
               run: mkdir -p doc
 
-            - name: panvimdoc
-              uses: kdheepak/panvimdoc@main
-              with:
-                  vimdoc: ${{ github.event.repository.name }}
-                  version: "Neovim >= 0.11.0"
-                  pandoc: "README.md"
-                  demojify: true
-                  treesitter: true
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@master
+
+            - name: Install vimcats
+              run: cargo install vimcats --features=cli
+
+            - name: Install Just
+              uses: extractions/setup-just@v3
+
+            - name: Generate docs
+              run: just doc
 
             - name: Push changes
               uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
 
             - name: Install Rust
               uses: dtolnay/rust-toolchain@master
+              with:
+                  toolchain: stable
 
             - name: Install vimcats
               run: cargo install vimcats --features=cli

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .tests/
+.direnv/

--- a/Justfile
+++ b/Justfile
@@ -1,11 +1,9 @@
 doc:
-    rm -rf doc/tool-resolver.nvim.txt
-
     vimcats -t -f -c -a \
     lua/tool-resolver/init.lua \
     lua/tool-resolver/config.lua \
     lua/tool-resolver/types.lua \
-    > doc/tool-resolver.txt
+    > doc/tool-resolver.nvim.txt
 
     nvim --headless -c "helptags doc" -c "q"
 

--- a/Justfile
+++ b/Justfile
@@ -5,7 +5,7 @@ doc:
     lua/tool-resolver/types.lua \
     > doc/tool-resolver.nvim.txt
 
-    nvim --headless -c "helptags doc" -c "q"
+    vim -c "helptags doc" -c "q"
 
 set shell := ["bash", "-cu"]
 

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,13 @@
 doc:
-    panvimdoc --project-name tool-resolver.nvim --input-file ./README.md --demojify true --vim-version "Neovim >= 0.11.0"
+    rm -rf doc/tool-resolver.nvim.txt
+
+    vimcats -t -f -c -a \
+    lua/tool-resolver/init.lua \
+    lua/tool-resolver/config.lua \
+    lua/tool-resolver/types.lua \
+    > doc/tool-resolver.txt
+
+    nvim --headless -c "helptags doc" -c "q"
 
 set shell := ["bash", "-cu"]
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,13 @@
+tool-resolver.api	tool-resolver.nvim.txt	/*tool-resolver.api*
+tool-resolver.api.get_bin	tool-resolver.nvim.txt	/*tool-resolver.api.get_bin*
+tool-resolver.api.setup	tool-resolver.nvim.txt	/*tool-resolver.api.setup*
+tool-resolver.config	tool-resolver.nvim.txt	/*tool-resolver.config*
+tool-resolver.config.config	tool-resolver.nvim.txt	/*tool-resolver.config.config*
+tool-resolver.toc	tool-resolver.nvim.txt	/*tool-resolver.toc*
+tool-resolver.txt	tool-resolver.nvim.txt	/*tool-resolver.txt*
+tool-resolver.types	tool-resolver.nvim.txt	/*tool-resolver.types*
+tool-resolver.types.ToolResolver.Config	tool-resolver.nvim.txt	/*tool-resolver.types.ToolResolver.Config*
+tool-resolver.types.ToolResolver.Config.Tools	tool-resolver.nvim.txt	/*tool-resolver.types.ToolResolver.Config.Tools*
+tool-resolver.types.ToolResolver.GetBinOpts	tool-resolver.nvim.txt	/*tool-resolver.types.ToolResolver.GetBinOpts*
+tool-resolver.types.ToolResolver.ResolverMeta	tool-resolver.nvim.txt	/*tool-resolver.types.ToolResolver.ResolverMeta*
+tool-resolver.types.ToolResolver.ResolverType	tool-resolver.nvim.txt	/*tool-resolver.types.ToolResolver.ResolverType*

--- a/doc/tool-resolver.nvim.txt
+++ b/doc/tool-resolver.nvim.txt
@@ -1,166 +1,103 @@
-*tool-resolver.nvim.txt*     For Neovim >= 0.11.0    Last change: 2025 July 15
+*tool-resolver.txt*
+
+Resolve project-local CLI tools in Neovim with monorepo-aware logic.
 
 ==============================================================================
-Table of Contents                       *tool-resolver.nvim-table-of-contents*
+Table of Contents                                            *tool-resolver.toc*
 
-1. tool-resolver.nvim                  |tool-resolver.nvim-tool-resolver.nvim|
-  - Features                  |tool-resolver.nvim-tool-resolver.nvim-features|
-  - How It Works          |tool-resolver.nvim-tool-resolver.nvim-how-it-works|
-  - Installation          |tool-resolver.nvim-tool-resolver.nvim-installation|
-  - Configuration        |tool-resolver.nvim-tool-resolver.nvim-configuration|
-  - Quick Start            |tool-resolver.nvim-tool-resolver.nvim-quick-start|
-  - API                            |tool-resolver.nvim-tool-resolver.nvim-api|
+API ························································ |tool-resolver.api|
+Configurations ·········································· |tool-resolver.config|
+Types ···················································· |tool-resolver.types|
 
 ==============================================================================
-1. tool-resolver.nvim                  *tool-resolver.nvim-tool-resolver.nvim*
+API                                                          *tool-resolver.api*
 
-Resolve project-local CLI tools in Neovim with monorepo-aware logic. Say bye to
-version mismatches!
+M.setup                                                *tool-resolver.api.setup*
+    Entry point to setup the plugin
 
-
-FEATURES                      *tool-resolver.nvim-tool-resolver.nvim-features*
-
-- Monorepo-friendly: climbs up directory tree to find local binaries
-- Falls back to monorepo root if needed
-- Global fallback to system binary if no local match
-- Smart per-buffer resolution (works as you switch files)
-- Lightweight, dependency-free
+    Type: ~
+        (fun(user_config?:ToolResolver.Config))
 
 
-  [!NOTE] This plugin currently only supports node projects, feel free to
-  contribute for more language resolvers if this plugin interests you.
+M.get_bin                                            *tool-resolver.api.get_bin*
+    Resolving tools for specified types. The tool will try to resolve the binary from the current buffer path,
+    then from cwd if not found, and finally fallback to the configured fallback or tool name.
 
-HOW IT WORKS              *tool-resolver.nvim-tool-resolver.nvim-how-it-works*
-
-When resolving a tool (e.g. `biome`), this plugin:
-
-1. Starts at the file’s directory
-2. Traverses upward to find the nearest executable based on configured type, for `node` it will be at `node_modules/.bin/biome`
-3. If none is found, tries the same logic from `vim.fn.getcwd()` (monorepo root fallback)
-4. If still not found, falls back to the fallbacks tool name specified in configuration or the global tool name (e.g. "biome")
+    Type: ~
+        (fun(tool:string,opts?:ToolResolver.GetBinOpts):string)  -- references the signature from resolvers.get_bin
 
 
-INSTALLATION              *tool-resolver.nvim-tool-resolver.nvim-installation*
-
-Using lazy.nvim <https://github.com/folke/lazy.nvim>
-
->lua
-    -- tool-resolver.lua
-    return {
-     "y3owk1n/tool-resolver.nvim",
-     version = "*", -- remove this if you want to use the `main` branch
-     opts = {
-      -- your configuration comes here
-      -- or leave it empty to use the default settings
-      -- refer to the configuration section below
-     }
-    }
-<
-
-Ifyou are using other package managers you need to call `setup`
-
->lua
-    require("tool-resolver").setup({
-      -- your configuration
-    })
-<
+==============================================================================
+Configurations                                            *tool-resolver.config*
 
 
-REQUIREMENTS ~
+Example Configuration:
 
-- Neovim0.11+ with Lua support
-
-
-CONFIGURATION            *tool-resolver.nvim-tool-resolver.nvim-configuration*
-
-The default configurations are as below.
-
-
-DEFAULT OPTIONS ~
-
->lua
-    ---@type ToolResolver.Config
-    {
-     tools = {},
-    }
-<
-
-
-TYPE DEFINITIONS ~
-
->lua
-    ---@class ToolResolver.Config
-    ---@field tools table<string, ToolResolver.Config.Tools> tools with type and fallback
-    
-    ---@class ToolResolver.Config.Tools
-    ---@field type ToolResolver.ResolverType
-    ---@field fallback? string fallback binary name, if not specified then use the key.
-<
-
-
-QUICK START                *tool-resolver.nvim-tool-resolver.nvim-quick-start*
-
-See the example below for how to configure **tool-resolver.nvim**.
-
->lua
-    {
-     "y3owk1n/tool-resolver.nvim",
-     cmd = {
-      "ToolResolverGetTool",
-      "ToolResolverGetTools",
-     },
-     ---@type ToolResolver.Config
-     opts = {
-       -- register the tools that you want to use here
-       tools = {
-        biome = {
-         type = "node", -- type is required, and only "node" is supported for now
-        },
-        prettier = {
-         type = "node", -- type is required, and only "node" is supported for now
-         fallback = "prettierd", -- specify a fallback binary name will resolve to this, else will fallback to the key `prettier`
-        },
-       },
-     },
+>
+{
+   -- register the tools that you want to use here
+   tools = {
+    biome = {
+     type = "node", -- type is required, and only "node" is supported for now
     },
-<
-
-You can then use the following to resolve a tool anywhere. For example in my
-biome LSP config:
-
->lua
-    local tr = require("tool-resolver")
-    
-    ---@type vim.lsp.Config
-    return {
-     cmd = { tr.get_bin("biome"), "lsp-proxy" }, -- instead of just getting it from the global bin, use tool-resolver for it.
-     -- the rest of your lsp configurations
-    }
+    prettier = {
+     type = "node", -- type is required, and only "node" is supported for now
+     fallback = "prettierd", -- specify a fallback binary name will resolve to this, else will fallback to the key `prettier`
+    },
+  },
+}
 <
 
 
-API                                *tool-resolver.nvim-tool-resolver.nvim-api*
+M.config                                           *tool-resolver.config.config*
+    User-provided config, merged with defaults
 
-**tool-resolver.nvim** provides the following api functions that you can use
-for different things:
+    Type: ~
+        (ToolResolver.Config)
 
 
-GET THE LOCAL OR GLOBAL TOOL BIN ~
+==============================================================================
+Types                                                      *tool-resolver.types*
 
-This is the most important function in **tool-resolver.nvim**. It will try to
-resolve the tool bin from the current buffer to the node modules available
-binary, and only fallback to the globally installed version.
+ToolResolver.Config                    *tool-resolver.types.ToolResolver.Config*
+    Config
 
->lua
-    ---@class ToolResolver.GetBinOpts
-    ---@field path? string start search path (default: current buffer)
-    
-    ---@param tool string
-    ---@param opts? ToolResolver.GetBinOpts
-    ---@return string
-    require("tool-resolver").get_bin(tool, opts)
-<
+    Fields: ~
+        {tools}  (table<string,ToolResolver.Config.Tools>)  tools with type and fallback
 
-Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+
+                                 *tool-resolver.types.ToolResolver.Config.Tools*
+ToolResolver.Config.Tools
+    Config Tools
+
+    Fields: ~
+        {type}       (ToolResolver.ResolverType)
+        {fallback?}  (string)                     fallback binary name, if not specified then use the key.
+
+
+                                   *tool-resolver.types.ToolResolver.GetBinOpts*
+ToolResolver.GetBinOpts
+    `get_bin` options
+
+    Fields: ~
+        {path?}  (string)  start search path (default: current buffer)
+
+
+                                 *tool-resolver.types.ToolResolver.ResolverType*
+ToolResolver.ResolverType
+    Resolver types
+
+    Variants: ~
+        ("node")  node-based resolver (e.g. using node_modules)
+
+
+                                 *tool-resolver.types.ToolResolver.ResolverMeta*
+ToolResolver.ResolverMeta
+    Resolver metadata
+
+    Fields: ~
+        {root_markers}  (string[])  root_markers
+        {bin_subpath}   (string[])  bin_subpath
+
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,28 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747426788,
+        "narHash": "sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG+K+jU57JGc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12a55407652e04dcf2309436eb06fef0d3713ef3",
+        "type": "github"
+      },
+      "original": {
+        "narHash": "sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG+K+jU57JGc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12a55407652e04dcf2309436eb06fef0d3713ef3",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3?narHash=sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG%2BK%2BjU57JGc%3D";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+    in
+    {
+      devShells = eachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              vimcats
+            ];
+          };
+        }
+      );
+    };
+}

--- a/lua/tool-resolver/config.lua
+++ b/lua/tool-resolver/config.lua
@@ -1,3 +1,25 @@
+---@mod tool-resolver.config Configurations
+---@brief [[
+---
+---Example Configuration:
+---
+--->
+---{
+---   -- register the tools that you want to use here
+---   tools = {
+---    biome = {
+---     type = "node", -- type is required, and only "node" is supported for now
+---    },
+---    prettier = {
+---     type = "node", -- type is required, and only "node" is supported for now
+---     fallback = "prettierd", -- specify a fallback binary name will resolve to this, else will fallback to the key `prettier`
+---    },
+---  },
+---}
+---<
+---
+---@brief ]]
+
 local M = {}
 
 local notify = require("tool-resolver.notify")
@@ -11,6 +33,7 @@ local inspect = vim.inspect
 ---@type ToolResolver.Config
 M.config = {}
 
+---@private
 ---@type ToolResolver.Config
 local defaults = {
 	tools = {},
@@ -102,7 +125,8 @@ local function setup_usercmds()
 	})
 end
 
---- Plugin setup entry point
+---@private
+---Plugin setup entry point
 ---@param user_config? ToolResolver.Config
 function M.setup(user_config)
 	M.config = vim.tbl_deep_extend("force", defaults, user_config or {})

--- a/lua/tool-resolver/init.lua
+++ b/lua/tool-resolver/init.lua
@@ -1,12 +1,27 @@
 ---@module "tool-resolver"
 
+---@brief [[
+---*tool-resolver.txt*
+---
+---Resolve project-local CLI tools in Neovim with monorepo-aware logic.
+---@brief ]]
+
+---@toc tool-resolver.toc
+
+---@mod tool-resolver.api API
+
 local config = require("tool-resolver.config")
 local resolvers = require("tool-resolver.resolvers")
 
 local M = {}
 
+---Entry point to setup the plugin
+---@type fun(user_config?: ToolResolver.Config)
 M.setup = config.setup
 
+---Resolving tools for specified types. The tool will try to resolve the binary from the current buffer path,
+---then from cwd if not found, and finally fallback to the configured fallback or tool name.
+---@type fun(tool: string, opts?: ToolResolver.GetBinOpts): string  -- references the signature from resolvers.get_bin
 M.get_bin = resolvers.get_bin
 
 return M

--- a/lua/tool-resolver/types.lua
+++ b/lua/tool-resolver/types.lua
@@ -1,15 +1,28 @@
+---@mod tool-resolver.types Types
+---
+
+local M = {}
+
+---Config
 ---@class ToolResolver.Config
 ---@field tools table<string, ToolResolver.Config.Tools> tools with type and fallback
 
+---Config Tools
 ---@class ToolResolver.Config.Tools
 ---@field type ToolResolver.ResolverType
 ---@field fallback? string fallback binary name, if not specified then use the key.
 
+---`get_bin` options
 ---@class ToolResolver.GetBinOpts
 ---@field path? string start search path (default: current buffer)
 
----@alias ToolResolver.ResolverType "node" -- add more in future
+---Resolver types
+---@alias ToolResolver.ResolverType
+---| '"node"' # node-based resolver (e.g. using node_modules)
 
+---Resolver metadata
 ---@class ToolResolver.ResolverMeta
 ---@field root_markers string[] root_markers
 ---@field bin_subpath string[] bin_subpath
+
+return M


### PR DESCRIPTION
- **fix(docs): switch from `pandocvim` to `vimcats` for docs generation**
- **ensure name consistent**
